### PR TITLE
fix(serve): propagate is_error to MCP wire on tool failures

### DIFF
--- a/src/ot/server.py
+++ b/src/ot/server.py
@@ -565,11 +565,14 @@ async def run(command: str, ctx: Context) -> ToolResult:  # noqa: ARG001
         )
 
     # Return ToolResult with content only — prevents FastMCP from auto-generating
-    # structuredContent (which Claude Code prefers over content text)
+    # structuredContent (which Claude Code prefers over content text).
+    # Propagate is_error from CommandResult so MCP clients see the failure flag
+    # on the wire and the LLM treats it as a tool error rather than success
+    # content.
     text = sanitize_output(
         result.result, enabled=result.should_sanitize, fmt=result.format
     )
-    return ToolResult(content=text)
+    return ToolResult(content=text, is_error=not result.success)
 
 
 def main() -> None:

--- a/src/otutil/tools/ground.py
+++ b/src/otutil/tools/ground.py
@@ -436,7 +436,7 @@ def _grounded_search(
 
         except Exception as e:
             s.add("error", str(e))
-            return _format_error(e)
+            raise
 
 
 def search(
@@ -598,8 +598,8 @@ def search_batch(
         return "Error: queries list cannot be empty"
     try:
         request_timeout = _get_config().timeout if timeout is None else timeout
-    except Exception as e:
-        return _format_error(e)
+    except Exception:
+        raise
     if error := _validate_request_timeout(request_timeout):
         return error
     if error := _validate_batch_retry_controls(retries, retry_delay_ms):

--- a/tests/unit/serve/test_run_is_error.py
+++ b/tests/unit/serve/test_run_is_error.py
@@ -1,0 +1,83 @@
+"""Regression tests for MCP wire-format error propagation.
+
+The `run` MCP tool wraps results from `execute_command` in a `ToolResult`.
+When the underlying Python execution fails (success=False), the wire result
+must carry `isError: true` so MCP clients (Claude Code, etc.) recognise the
+failure as a tool error instead of treating it as success content.
+
+This guards against the bug class flagged in
+https://composio.dev/blog/mcp-security-vulnerabilities where error strings
+were returned in `content` while `isError` stayed false, causing LLMs to
+ignore the failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.serve
+def test_run_returns_toolresult_with_is_error_false_on_success() -> None:
+    """A successful execution must produce is_error=False (default)."""
+    from ot.executor.runner import CommandResult
+    from ot.server import run
+
+    ok_result = CommandResult(
+        command="print('hi')",
+        result="hi",
+        success=True,
+        error_type=None,
+        should_sanitize=True,
+        format="text",
+    )
+
+    with patch("ot.server.execute_command", return_value=ok_result), \
+         patch("ot.server.prepare_command") as prep, \
+         patch("ot.server._stats_writer", None), \
+         patch("ot.server.get_client_name", return_value="test"):
+        prep.return_value.error = None
+        prep.return_value.code = "print('hi')"
+
+        tool_result = asyncio.run(run(command="print('hi')", ctx=None))
+
+    assert tool_result.is_error is False
+
+
+@pytest.mark.unit
+@pytest.mark.serve
+def test_run_returns_toolresult_with_is_error_true_on_failure() -> None:
+    """A failed execution must produce is_error=True so the wire CallToolResult
+    carries isError=true and the LLM treats it as a tool failure."""
+    from ot.executor.runner import CommandResult
+    from ot.server import run
+
+    fail_result = CommandResult(
+        command="ground.search(query='x')",
+        result="ValueError: invalid tools.ground configuration",
+        success=False,
+        error_type="ValueError",
+        should_sanitize=True,
+        format="text",
+    )
+
+    with patch("ot.server.execute_command", return_value=fail_result), \
+         patch("ot.server.prepare_command") as prep, \
+         patch("ot.server._stats_writer", None), \
+         patch("ot.server.get_client_name", return_value="test"):
+        prep.return_value.error = None
+        prep.return_value.code = "ground.search(query='x')"
+
+        tool_result = asyncio.run(run(command="ground.search(query='x')", ctx=None))
+
+    assert tool_result.is_error is True
+    # The error message is preserved in content for the LLM to read.
+    assert tool_result.content is not None
+    text_blocks = [
+        b for b in tool_result.content if getattr(b, "type", None) == "text"
+    ]
+    assert text_blocks, "expected a text content block carrying the error"
+    assert "ValueError" in text_blocks[0].text


### PR DESCRIPTION
## Summary

The `run` MCP tool returned `ToolResult(content=text)` regardless of whether `execute_command` produced `success=False`. Exceptions surfaced to the LLM as plain text in `content` with `isError: false` on the wire, so MCP clients treated failures as success content and the model often proceeded as if the call had succeeded.

This is the same `isError`-compliance gap flagged in the recent MCP security audit (Dayna Blackwell, Tool Poisoning, Rug Pulls, and Prompt Injections — oh my!) — error text without `isError: true` is treated as data, not failure, which LLMs can act on.

## Changes

- `src/ot/server.py`: set `ToolResult.is_error` from `result.success` so the `CallToolResult` carries `isError: true` on the wire.
- `src/otutil/tools/ground.py`: re-raise from the two bare `except` handlers in `_grounded_search` and `search_batch` so `execute_command`'s `success=False` propagation triggers.
- `tests/unit/serve/test_run_is_error.py`: regression coverage for both success and failure paths through the `run` tool.

## Tests

```
$ pytest tests/unit/serve/test_run_is_error.py -v
tests/unit/serve/test_run_is_error.py::test_run_returns_toolresult_with_is_error_false_on_success PASSED
tests/unit/serve/test_run_is_error.py::test_run_returns_toolresult_with_is_error_true_on_failure PASSED
2 passed
```

`ruff check` clean. 95 unit tests in `tests/unit/serve/` and `tests/unit/tools/` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses from tool runs now correctly signal failures to clients, while still returning sanitized output when available.
  * Search-related failures now propagate as real exceptions instead of being converted into generic error text, improving reliability and error handling.

* **Tests**
  * Added regression coverage to verify successful and failed tool runs set the correct error state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->